### PR TITLE
Cache for certificate

### DIFF
--- a/Alexa.NET.Security.Functions/Alexa.NET.Security.Functions.csproj
+++ b/Alexa.NET.Security.Functions/Alexa.NET.Security.Functions.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Alexa.NET" Version="1.5.7" />
+    <PackageReference Include="Alexa.NET" Version="1.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.1" />
   </ItemGroup>

--- a/Alexa.NET.Security.Functions/AlexaRequestValidationFunctionsExtension.cs
+++ b/Alexa.NET.Security.Functions/AlexaRequestValidationFunctionsExtension.cs
@@ -89,18 +89,25 @@ namespace Alexa.NET.Security.Functions
 
         private static async Task<X509Certificate2> GetCertificate(Uri signatureCertChainUrl)
         {
-            if(signatureCertChainUrl == null)
+            if (signatureCertChainUrl == null)
                 return null;
 
-            if (certificateCache.Key == null || certificateCache.Key.ToString() != signatureCertChainUrl.ToString())
+            if (certificateCache.Key == null || certificateCache.Key.ToString().ToLowerInvariant() != signatureCertChainUrl.ToString().ToLowerInvariant())
             {
-                X509Certificate2 certificate = await RequestVerification.GetCertificate(signatureCertChainUrl);
-                if (certificate != null)
-                    certificateCache = new KeyValuePair<Uri, X509Certificate2>(signatureCertChainUrl, certificate);
+                try
+                {
+                    X509Certificate2 certificate = await RequestVerification.GetCertificate(signatureCertChainUrl);
+                    if (certificate != null)
+                        certificateCache = new KeyValuePair<Uri, X509Certificate2>(signatureCertChainUrl, certificate);
 
-                return certificate;
+                    return certificate;
+                }
+                catch
+                {
+                    return null;
+                }
             }
-            else 
+            else
                 return certificateCache.Value;
         }
 

--- a/Alexa.NET.Security.Functions/AlexaRequestValidationFunctionsExtension.cs
+++ b/Alexa.NET.Security.Functions/AlexaRequestValidationFunctionsExtension.cs
@@ -89,20 +89,19 @@ namespace Alexa.NET.Security.Functions
 
         private static async Task<X509Certificate2> GetCertificate(Uri signatureCertChainUrl)
         {
+            if(signatureCertChainUrl == null)
+                return null;
+
             if (certificateCache.Key == null || certificateCache.Key.ToString() != signatureCertChainUrl.ToString())
             {
                 X509Certificate2 certificate = await RequestVerification.GetCertificate(signatureCertChainUrl);
                 if (certificate != null)
-                {
                     certificateCache = new KeyValuePair<Uri, X509Certificate2>(signatureCertChainUrl, certificate);
-                }
 
                 return certificate;
             }
-            else
-            {
+            else 
                 return certificateCache.Value;
-            }
         }
 
         /// <summary>

--- a/Alexa.NET.Security.Functions/AlexaRequestValidationFunctionsExtension.cs
+++ b/Alexa.NET.Security.Functions/AlexaRequestValidationFunctionsExtension.cs
@@ -3,12 +3,16 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 namespace Alexa.NET.Security.Functions
 {
     public static class AlexaRequestValidationFunctionsExtension
     {
+        private static KeyValuePair<Uri, X509Certificate2> certificateCache;
+
         /// <summary>
         /// Validates an incoming request against Amazon security guidelines.
         /// </summary>
@@ -83,6 +87,24 @@ namespace Alexa.NET.Security.Functions
             return signatureCertChainUrl;
         }
 
+        private static async Task<X509Certificate2> GetCertificate(Uri signatureCertChainUrl)
+        {
+            if (certificateCache.Key == null || certificateCache.Key.ToString() != signatureCertChainUrl.ToString())
+            {
+                X509Certificate2 certificate = await RequestVerification.GetCertificate(signatureCertChainUrl);
+                if (certificate != null)
+                {
+                    certificateCache = new KeyValuePair<Uri, X509Certificate2>(signatureCertChainUrl, certificate);
+                }
+
+                return certificate;
+            }
+            else
+            {
+                return certificateCache.Value;
+            }
+        }
+
         /// <summary>
         /// Gets the Signature value from http request headers.
         /// </summary>
@@ -124,7 +146,7 @@ namespace Alexa.NET.Security.Functions
         /// <returns></returns>
         private static async Task<bool> IsRequestValid(string signature, Uri signatureCertChainUrl, string body)
         {
-            return await RequestVerification.Verify(signature, signatureCertChainUrl, body);
+            return await RequestVerification.Verify(signature, signatureCertChainUrl, body, GetCertificate);
         }
     }
 }


### PR DESCRIPTION
- Alexa.NET package updated to version 1.13.0
- Added a cache for the certificate to reduce the time required for request verification.